### PR TITLE
Feature/remove dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ WORKDIR /rl_tournament
 RUN python3 -m pip install --upgrade pip
 RUN python3 -m pip install -r requirements.txt
 RUN git clone https://github.com/alan-turing-institute/plark_ai_public
+RUN cd plark_ai_public; git checkout feature/newgame-base
 RUN cd plark_ai_public/Components/plark-game; pip3 install .
 
 ### TOTAL HACK - MUST BE A BETTER WAY TO INSTALL resources/font.tff

--- a/api/API_DOCS.md
+++ b/api/API_DOCS.md
@@ -1,0 +1,86 @@
+## API endpoints for querying the Plark tournament DB
+
+Note that all the endpoints below follow the base URL, which would be:
+```
+localhost:5001
+```
+if running on your local machine, or something like:
+```
+https://<webapp_name>.azurewebsites.net
+```
+if deploying as an Azure web app.
+
+### Endpoints:
+
+*```/tournaments```*
+lists all the tournaments, returns
+```
+[ {"tournament_id": <id:int>, "tournament_time": <time:str>}, ... ]
+```
+
+*```/tournaments/<tourn_id>```*
+info on tournament with id <tourn_id>, returns
+```
+{
+  "tournament_id": <id:int>,
+  "tournament_time": <time:str>,
+  "panther_agents": [<agent_name>:str, ...],
+  "pelican_agents": [<agent_name>:str, ...],
+  "matches": [<match_id>:int, ...]
+}
+```
+
+*```/matches/<match_id>```*
+info on match with id <match_id>, returns
+```
+{
+  "match_id": <id:int>,
+  "match_time": <time:str>,
+  "panther": <agent_name>:str,
+  "pelican": <agent_name>:str,
+  "panther_score": <score>:int,
+  "pelican_score": <score>:int,
+  "winner": <agent_name>:str,
+  "logfile": <log_url>:str,
+  "games": [<game_id>:int, ...]
+}
+```
+
+*```/games/<games_id>```*
+info on game with id <game_id>, returns
+```
+{
+  "game_id": <id:int>,
+  "game_time": <time:str>,
+  "panther": <agent_name>:str,
+  "pelican": <agent_name>:str,
+  "num_turns": <num_turns>:int,
+  "result_code": <code>:str,
+  "winner": <agent_type>:str,
+  "video": <video_url>:str
+}
+```
+
+*```/teams```*
+list of all teams, returns
+```
+[ <team_name>:str, ... ]
+```
+
+*```/agents/<team_name>```*
+list of all agents for a given team, returns
+```
+[ <agent_name>:str, ... ]
+```
+
+*```/pelicans/<tournament_id>```*
+list of all pelican agents for a given tournament_id, returns
+```
+[ <agent_name>:str, ... ]
+```
+
+*```/panthers/<tournament_id>```*
+list of all pelican agents for a given tournament_id, returns
+```
+[ <agent_name>:str, ... ]
+```

--- a/api/api_utils.py
+++ b/api/api_utils.py
@@ -30,13 +30,16 @@ def list_agents(
     Return a list of agent names.
     """
     agents_query = dbsession.query(Agent)
-    if tournament != "all":
-        agents_query = agents_query.filter_by(tournament_id=tournament)
+
     if agent_type != "all":
         agents_query = agents_query.filter_by(agent_type=agent_type)
     if team != "all":
         agents_query = agents_query.filter(Agent.team.has(team_name=team))
-    return [agent.agent_name for agent in agents_query.all()]
+    agents = agents_query.all()
+    if tournament != "all":
+        agents = [a for a in agents if int(tournament) in \
+                  [t.tournament_id for t in a.tournaments]]
+    return [agent.agent_name for agent in agents]
 
 
 def list_tournaments(dbsession=session):

--- a/api/app.py
+++ b/api/app.py
@@ -10,6 +10,7 @@ from flask_cors import CORS
 from flask_session import Session
 
 from api_utils import (
+    list_agents,
     list_teams,
     list_tournaments,
     get_tournament,
@@ -74,6 +75,33 @@ def get_tournament_info(tid):
     """
     tournament = get_tournament(tid)
     return create_response(tournament)
+
+
+@blueprint.route("/agents/<team_name>", methods=["GET"])
+def get_agent_list(team_name):
+    """
+    Return a list of all agents for a given team
+    """
+    agents = list_agents(team=team_name)
+    return create_response(agents)
+
+
+@blueprint.route("/pelicans/<tid>", methods=["GET"])
+def get_pelican_list(tid):
+    """
+    Return a list of all agents for a given team
+    """
+    agents = list_agents(tournament=tid, agent_type="pelican")
+    return create_response(agents)
+
+
+@blueprint.route("/panthers/<tid>", methods=["GET"])
+def get_panther_list(tid):
+    """
+    Return a list of all agents for a given team
+    """
+    agents = list_agents(tournament=tid, agent_type="panther")
+    return create_response(agents)
 
 
 @blueprint.route("/matches/<mid>", methods=["GET"])

--- a/battleground/battleground.py
+++ b/battleground/battleground.py
@@ -309,10 +309,10 @@ class Battle(Newgame):
         ].get_normalised_observation(game_state)
         domain_parameters = self.observation[
             agent_type
-        ].get_domain_parameters()
+        ].get_remaining_domain_parameters()
         domain_parameters_normalised = self.observation[
             agent_type
-        ].get_normalised_domain_parameters()
+        ].get_normalised_remaining_domain_parameters()
         body = {
             "state": serialized_game_state,
             "obs": obs,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 pika==1.1.0
 jsonpickle==1.5.0
-stable-baselines==2.10.1
-tensorflow==1.14
 pytest==6.2.1
 black==20.8b1
 flake8==3.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pre-commit==2.10.0
 marshmallow==3.10.0
 imageio==2.9.0
 flake8==3.8.4
+setuptools-rust==0.11.6
 
 sqlalchemy==1.3.23
 imageio-ffmpeg==0.4.3


### PR DESCRIPTION
* Battle now inherits from NewgameBase in plark_ai_public, rather than Newgame, so we have no dependency on e.g. tensorflow or stable_baselines any more.
* Fixes to which Observation belongs to which agent.
* Battle now waits for RabbitMQ to be ready when setting up the "agents_ready" queue.