### PR TITLE
Bugfix/pika heartbeat

### DIFF
--- a/api/api_utils.py
+++ b/api/api_utils.py
@@ -122,7 +122,7 @@ def get_match(match_id, dbsession=session):
         "config": match.game_config,
         "panther_score": match.score("panther"),
         "pelican_score": match.score("pelican"),
-        "winner": match.winning_agent.agent_name,
+        "winner": match.winning_agent.agent_name if match.winning_agent else "Tie",
         "games": [g.game_id for g in match.games],
     }
 

--- a/battleground/battleground.py
+++ b/battleground/battleground.py
@@ -129,7 +129,11 @@ class Battleground():
         while not connected:
             try:
                 self.connection = pika.BlockingConnection(
-                    pika.ConnectionParameters(host=hostname)
+                    pika.ConnectionParameters(
+                        host=hostname,
+                        heartbeat=600,
+                        blocked_connection_timeout=300
+                    )
                 )
                 connected = True
             except (
@@ -271,7 +275,11 @@ class Battle(NewgameBase):
         while not connected:
             try:
                 self.connection = pika.BlockingConnection(
-                    pika.ConnectionParameters(host=hostname)
+                    pika.ConnectionParameters(
+                        host=hostname,
+                        heartbeat=600,
+                        blocked_connection_timeout=300
+                    )
                 )
                 connected = True
             except (


### PR DESCRIPTION
We occasionally see crashes (see #17 ) where the battleground loses its connection to the message queue.

This PR adds some parameters to the Pika connection that can hopefully avoid any timeouts.

Also a minor fix to the API, for the case where a match is drawn so there is no "winning_agent".