### PR TITLE
Feature/tournament plot

### DIFF
--- a/api/api_utils.py
+++ b/api/api_utils.py
@@ -21,7 +21,9 @@ def create_response(orig_response):
 def list_teams(dbsession=session):
     try:
         teams = dbsession.query(Team).all()
-        return [team.team_name for team in teams]
+        team_names = [team.team_name for team in teams]
+        dbsession.expunge_all()
+        return team_names
     except:
         dbsession.rollback()
         return []
@@ -46,7 +48,9 @@ def list_agents(
     if tournament != "all":
         agents = [a for a in agents if int(tournament) in \
                   [t.tournament_id for t in a.tournaments]]
-    return [agent.agent_name for agent in agents]
+    agent_names = [agent.agent_name for agent in agents]
+    dbsession.expunge_all()
+    return agent_names
 
 
 def list_tournaments(dbsession=session):
@@ -55,13 +59,15 @@ def list_tournaments(dbsession=session):
     except:
         dbsession.rollback()
         return []
-    return [
+    tournament_list = [
         {
             "tournament_id": t.tournament_id,
             "tournament_time": t.tournament_time.isoformat().split(".")[0],
         }
         for t in tournaments
     ]
+    dbsession.expunge_all()
+    return tournament_list
 
 
 def list_matches(tournament_id="all", dbsession=session):
@@ -73,7 +79,7 @@ def list_matches(tournament_id="all", dbsession=session):
     except:
         dbsession.rollback()
         return []
-    return [
+    match_list = [
         {
             "match_id": m.match_id,
             "match_time": m.match_time.isoformat().split(".")[0],
@@ -82,6 +88,8 @@ def list_matches(tournament_id="all", dbsession=session):
         }
         for m in matches
     ]
+    dbsession.expunge_all()
+    return match_list
 
 
 def get_tournament(tournament_id, dbsession=session):
@@ -96,7 +104,7 @@ def get_tournament(tournament_id, dbsession=session):
         return {}
     if not tournament:
         return {}
-    return {
+    tournament_info = {
         "tournament_id": tournament.tournament_id,
         "tournament_time": tournament.tournament_time.isoformat().split(".")[
             0
@@ -113,6 +121,8 @@ def get_tournament(tournament_id, dbsession=session):
         ],
         "matches": [m.match_id for m in tournament.matches],
     }
+    dbsession.expunge_all()
+    return tournament_info
 
 
 def get_match_id(tournament_id, panther, pelican, dbsession=session):
@@ -129,7 +139,9 @@ def get_match_id(tournament_id, panther, pelican, dbsession=session):
         return {}
     if not match:
         return {}
-    return {"match_id": match.match_id}
+    match_id = match.match_id
+    dbsession.expunge_all()
+    return {"match_id": match_id}
 
 
 def get_match(match_id, dbsession=session):
@@ -140,7 +152,7 @@ def get_match(match_id, dbsession=session):
         return {}
     if not match:
         return {}
-    return {
+    match_info = {
         "match_id": match.match_id,
         "match_time": match.match_time.isoformat().split(".")[0],
         "pelican": match.pelican_agent.agent_name,
@@ -152,6 +164,8 @@ def get_match(match_id, dbsession=session):
         "winner": match.winning_agent.agent_name if match.winning_agent else "Tie",
         "games": [g.game_id for g in match.games],
     }
+    dbsession.expunge_all()
+    return match_info
 
 
 def get_game(game_id, dbsession=session):
@@ -162,7 +176,7 @@ def get_game(game_id, dbsession=session):
         return {}
     if not game:
         return {}
-    return {
+    game_info = {
         "game_id": game.game_id,
         "game_time": game.game_time.isoformat().split(".")[0],
         "pelican": game.match.pelican_agent.agent_name,
@@ -172,3 +186,5 @@ def get_game(game_id, dbsession=session):
         "result_code": game.result_code,
         "winner": game.winner,
     }
+    dbsession.expunge_all()
+    return game_info

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -18,6 +18,14 @@ app = Flask(__name__)
 @app.route("/")
 def homepage():
     """
+    basic homepage - list the interesting tournaments.
+    """
+    return render_template("index.html")
+
+
+@app.route("/tournaments")
+def tournaments():
+    """
     basic homepage - options to view results table or run a new test.
     """
     r = requests.get(BASE_URL+"/tournaments")
@@ -25,7 +33,7 @@ def homepage():
         raise RuntimeError("Couldn't reach API")
 
     tournaments = r.json()
-    return render_template("index.html", tournaments=tournaments,
+    return render_template("tournamentlist.html", tournaments=tournaments,
                            base_url=BASE_URL)
 
 

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -1,2 +1,4 @@
 flask==1.1.2
 requests==2.25.1
+pandas==1.2.1
+plotly==4.14.3

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -1,4 +1,4 @@
 flask==1.1.2
 requests==2.25.1
-pandas==1.2.1
+pandas==1.1.5
 plotly==4.14.3

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -15,4 +15,10 @@
 	<td><a href=tournament/55> 10x10</a></td>
 	<td><a href=tournament/56> 25x25</a></td>
       </tr>
+      <tr>
+	<td>
+	  <h3>Monday 8th March  </h3>
+	</td>
+	<td><a href=tournament/72> 26x33</a></td>
+      </tr>
     </table>

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -8,12 +8,11 @@
   <div>
     <h2>Tournaments</h2>
     <table>
-      {% for row in tournaments %}
       <tr>
-	<td>{{ row.tournament_id }}</td><td><a href=tournament/{{ row.tournament_id }}>{{ row.tournament_time }}</a></td>
+	<td>
+	  <h3>Friday 5th March  </h3>
+	</td>
+	<td><a href=tournament/55> 10x10</a></td>
+	<td><a href=tournament/56> 25x25</a></td>
       </tr>
-      {% endfor %}
-</table>
-</div>
-</body>
-</html>
+    </table>

--- a/frontend/templates/match.html
+++ b/frontend/templates/match.html
@@ -20,14 +20,14 @@
       </tr>
       {% for row in games %}
       <tr>
-	<td>{{ row.game_id }}</td>
-	<td>{{ row.game_time }}
-	<td>{{ row.pelican }}
-	<td>{{ row.panther }}
-	<td>{{ row.num_turns }}</td>
-	<td>{{ row.result_code }}</td>
-	<td>{{ row.winner }}</td>
-	<td><a href={{ row.video }}>video</a> </td>
+	<td> {{ row.game_id }} </td>
+	<td> {{ row.game_time }} </td>
+	<td> {{ row.pelican }} </td>
+	<td> {{ row.panther }} </td>
+	<td> {{ row.num_turns }} </td>
+	<td> {{ row.result_code }} </td>
+	<td> {{ row.winner }} </td>
+	<td><a href={{ row.video }}> video </a> </td>
       </tr>
       {% endfor %}
 </table>

--- a/frontend/templates/tournament.html
+++ b/frontend/templates/tournament.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
 <html lang='en'>
-<head>
+  <head>
+    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
   <meta charset="utf-8" />
   <title>Tournament {{ tid }}</title>
 </head>
-<body>
+  <body>
+    {% autoescape off %}
+    {{ plot }}
+    {% endautoescape %}
   <div>
     <h2>Matches in tournament {{ tid }}</h2>
     <table>

--- a/frontend/templates/tournament.html
+++ b/frontend/templates/tournament.html
@@ -24,14 +24,14 @@
       </tr>
       {% for row in matches %}
       <tr>
-	<td>{{ row.match_id }}</td>
-	<td>{{ row.config }}
-	<td>{{ row.pelican }}</td>
-	<td>{{ row.panther }}</td>
-	<td>{{ row.pelican_score }}</td>
-	<td>{{ row.panther_score }}</td>
-	<td><a href={{ row.logfile }}>logfile</a> </td>
-	<td><a href=../match/{{ row.match_id }}>game details</a></td>
+	<td>  {{ row.match_id }} </td>
+	<td>  {{ row.config }} </td>
+	<td>  {{ row.pelican }} </td>
+	<td>  {{ row.panther }} </td>
+	<td>  {{ row.pelican_score }} </td>
+	<td>  {{ row.panther_score }} </td>
+	<td><a href={{ row.logfile }}> logfile </a> </td>
+	<td><a href=../match/{{ row.match_id }}> game details </a></td>
       </tr>
       {% endfor %}
 </table>

--- a/frontend/templates/tournamentlist.html
+++ b/frontend/templates/tournamentlist.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang='en'>
+<head>
+  <meta charset="utf-8" />
+  <title>Welcome to Plark Tournament!</title>
+</head>
+<body>
+  <div>
+    <h2>Tournaments</h2>
+    <table>
+      {% for row in tournaments %}
+      <tr>
+	<td>{{ row.tournament_id }}</td><td><a href=tournament/{{ row.tournament_id }}>{{ row.tournament_time }}</a></td>
+      </tr>
+      {% endfor %}
+</table>
+</div>
+</body>
+</html>

--- a/frontend/tournament_plot.py
+++ b/frontend/tournament_plot.py
@@ -18,7 +18,10 @@ def get_tournament_fig(data_dict):
     )
     fig.for_each_annotation(lambda a: a.update(text=a.text.split("=")[-1]))
     fig.for_each_trace(lambda t: t.update(name=t.name.split("=")[-1]))
-    fig.for_each_annotation(lambda a: a.update(textangle=0) if "pelican" in a.text else a)
+    fig.for_each_annotation(lambda a: a.update(textangle=0) \
+                            if "pelican" in a.text else a)
+    fig.for_each_annotation(lambda a: a.update(textangle=-15) \
+                            if "panther" in a.text else a)
 
     # modify the layout, labels etc.
     fig.update_yaxes(visible=False)
@@ -31,7 +34,7 @@ def get_tournament_fig(data_dict):
             xanchor="auto",
             x=0.5
         ),
-        margin=dict(l=20, r=240, t=50, b=20)
+        margin=dict(l=20, r=240, t=90, b=20)
     )
     div = io.to_html(fig, full_html=False, include_plotlyjs=False)
     return div

--- a/frontend/tournament_plot.py
+++ b/frontend/tournament_plot.py
@@ -1,0 +1,37 @@
+import pandas as pd
+import plotly.express as px
+from plotly import io
+
+def get_tournament_fig(data_dict):
+
+    df = pd.DataFrame.from_dict(data_dict)
+
+
+    fig = px.bar(
+        df,
+        x="score",
+        y="agent_type",
+        color="agent_type",
+        facet_col="panther",
+        facet_row="pelican",
+        orientation="h"
+    )
+    fig.for_each_annotation(lambda a: a.update(text=a.text.split("=")[-1]))
+    fig.for_each_trace(lambda t: t.update(name=t.name.split("=")[-1]))
+    fig.for_each_annotation(lambda a: a.update(textangle=0) if "pelican" in a.text else a)
+
+    # modify the layout, labels etc.
+    fig.update_yaxes(visible=False)
+    fig.update_xaxes(visible=False)
+    fig.update_layout(
+        legend=dict(
+            orientation="h",
+            yanchor="top",
+            y=-0.04,
+            xanchor="auto",
+            x=0.5
+        ),
+        margin=dict(l=20, r=240, t=50, b=20)
+    )
+    div = io.to_html(fig, full_html=False, include_plotlyjs=False)
+    return div


### PR DESCRIPTION
Improvements to the frontend
* Add a plotly figure showing bar charts for the numbers of pelican and panther wins for each match.
* New front page, only listing the "official" tournaments - move list of all tournaments to "/tournaments/" (`templates/tournamentlist.html`)
* Fix some missing `</td>` in the tables.